### PR TITLE
fixes label test

### DIFF
--- a/tests/features/AddressTest.php
+++ b/tests/features/AddressTest.php
@@ -138,7 +138,7 @@ class AddressTest extends TestCase
 
         $this->assertEquals(
             $attributes->implode(config('enso.addresses.label.separator')),
-            $this->testModel->getLabelAttribute()
+            $this->testModel->label()
         );
     }
 

--- a/tests/features/AddressTest.php
+++ b/tests/features/AddressTest.php
@@ -131,13 +131,13 @@ class AddressTest extends TestCase
     /** @test */
     public function can_get_label_attribute()
     {
-        $this->testModel->street = 'street';
-        $this->testModel->number = 'number';
-        $this->testModel->city = 'city';
-        $this->testModel->country->name = 'country';
+        $attributes = collect(config('enso.addresses.label.attributes'));
+        $attributes->each(function ($attribute) {
+            $this->testModel->{$attribute} = $attribute;
+        });
 
         $this->assertEquals(
-            'number street, city, country',
+            $attributes->implode(config('enso.addresses.label.separator')),
             $this->testModel->getLabelAttribute()
         );
     }


### PR DESCRIPTION
`get_label_test` used hard codded attributes. Now it uses config values.